### PR TITLE
Add oc_to_mdl reverse converter with metadata preservation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,15 @@ jobs:
             ./bin/mdl_to_cpp "$mdl"
           done
 
+      - name: Round-trip test (mdl_to_oc → oc_to_mdl)
+        run: |
+          for mdl in models/*.mdl; do
+            name=$(basename "$mdl" .mdl)
+            echo "Round-trip test: $name"
+            ./bin/oc_to_mdl "${name}-oc/" -o "${name}_roundtrip.mdl"
+            echo "  Generated ${name}_roundtrip.mdl"
+          done
+
       - name: Upload generated artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -45,3 +54,4 @@ jobs:
             *-oc/
             *-yaml/
             *-cpp/
+            *_roundtrip.mdl

--- a/makefile
+++ b/makefile
@@ -9,7 +9,7 @@ TOOLS_DIR := tools
 MODELS_DIR := models
 
 # Tool definitions
-TOOLS := mdl_to_oc mdl_to_yaml mdl_to_cpp mdl_dump mdl_lint
+TOOLS := mdl_to_oc mdl_to_yaml mdl_to_cpp mdl_dump mdl_lint oc_to_mdl
 
 # Find all MDL files in models directory
 MDL_FILES := $(wildcard $(MODELS_DIR)/*.mdl)
@@ -36,6 +36,9 @@ mdl_dump: $(BIN_DIR)
 mdl_lint: $(BIN_DIR)
 	$(CXX) $(CXXFLAGS) -o $(BIN_DIR)/$@ $(TOOLS_DIR)/mdl_lint/main.cpp
 
+oc_to_mdl: $(BIN_DIR)
+	$(CXX) $(CXXFLAGS) -o $(BIN_DIR)/$@ $(TOOLS_DIR)/oc_to_mdl/main.cpp
+
 test: mdl_lint
 	@echo ""
 	@echo "Running MDL lint on all models in $(MODELS_DIR)/"
@@ -53,6 +56,7 @@ clean:
 	rm -f $(TOOLS_DIR)/mdl_to_cpp/mdl_to_cpp
 	rm -f $(TOOLS_DIR)/mdl_dump/mdl_dump
 	rm -f $(TOOLS_DIR)/mdl_lint/mdl_lint
+	rm -f $(TOOLS_DIR)/oc_to_mdl/oc_to_mdl
 
 install: all
 	install -d /usr/local/bin
@@ -60,12 +64,14 @@ install: all
 	install -m 755 $(BIN_DIR)/mdl_to_yaml /usr/local/bin/
 	install -m 755 $(BIN_DIR)/mdl_to_cpp /usr/local/bin/
 	install -m 755 $(BIN_DIR)/mdl_lint /usr/local/bin/
+	install -m 755 $(BIN_DIR)/oc_to_mdl /usr/local/bin/
 
 uninstall:
 	rm -f /usr/local/bin/mdl_to_oc
 	rm -f /usr/local/bin/mdl_to_yaml
 	rm -f /usr/local/bin/mdl_to_cpp
 	rm -f /usr/local/bin/mdl_lint
+	rm -f /usr/local/bin/oc_to_mdl
 
 help:
 	@echo "Open Controls Build System"
@@ -83,3 +89,4 @@ help:
 	@echo "  mdl_to_cpp  - MDL to C++ code generator"
 	@echo "  mdl_dump    - MDL structure inspector"
 	@echo "  mdl_lint    - MDL model validator"
+	@echo "  oc_to_mdl   - OC to MDL format converter"

--- a/tools/libmdl/oc_mdl.hpp
+++ b/tools/libmdl/oc_mdl.hpp
@@ -314,6 +314,7 @@ namespace oc::mdl {
         std::string destination;
         std::vector<int> points;
         std::vector<branch> branches;
+        std::string labels;
 
         [[nodiscard]] auto source_endpoint() const { return endpoint::parse(source); }
         [[nodiscard]] auto destination_endpoint() const { return endpoint::parse(destination); }
@@ -328,6 +329,9 @@ namespace oc::mdl {
         std::string name;
         std::vector<int> location;
         int zoom_factor = 100;
+        int sid_highwatermark = 0;
+        std::string open;
+        std::string report_name;
 
         std::vector<block> blocks;
         std::vector<connection> connections;
@@ -486,10 +490,17 @@ namespace oc::mdl {
             auto root = parser.parse(xml_content);
 
             for (const auto* p : root.children_by_tag("P")) {
-                if (p->attr("Name") == "Location") {
+                auto pname = p->attr("Name");
+                if (pname == "Location") {
                     sys.location = parse_int_array(p->text);
-                } else if (p->attr("Name") == "ZoomFactor") {
+                } else if (pname == "ZoomFactor") {
                     sys.zoom_factor = std::stoi(p->text);
+                } else if (pname == "SIDHighWatermark") {
+                    sys.sid_highwatermark = std::stoi(p->text);
+                } else if (pname == "Open") {
+                    sys.open = p->text;
+                } else if (pname == "ReportName") {
+                    sys.report_name = p->text;
                 }
             }
 
@@ -595,6 +606,8 @@ namespace oc::mdl {
                     conn.destination = p->text;
                 } else if (name == "Points") {
                     conn.points = parse_int_array(p->text);
+                } else if (name == "Labels") {
+                    conn.labels = p->text;
                 }
             }
 
@@ -673,6 +686,7 @@ namespace oc::mdl {
         }
 
         [[nodiscard]] auto get_model() const -> const model& { return model_; }
+        [[nodiscard]] auto get_opc() const -> const opc_extractor& { return opc_; }
 
     private:
         void parse_blockdiagram(std::string_view xml_content) {

--- a/tools/liboc/oc_json.hpp
+++ b/tools/liboc/oc_json.hpp
@@ -1,0 +1,383 @@
+//
+// Open Controls - Minimal JSON Parser/Emitter
+//
+// Copyright (C) 2026 Daher Alfawares
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+
+#pragma once
+
+#include <string>
+#include <string_view>
+#include <vector>
+#include <map>
+#include <variant>
+#include <optional>
+#include <sstream>
+#include <stdexcept>
+#include <cctype>
+#include <iomanip>
+#include <cmath>
+
+namespace oc::json {
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // JSON Value Type
+    // ─────────────────────────────────────────────────────────────────────────────
+
+    class value;
+    using object = std::map<std::string, value>;
+    using array = std::vector<value>;
+
+    class value {
+    public:
+        using variant_type = std::variant<
+            std::nullptr_t,
+            bool,
+            double,
+            std::string,
+            array,
+            object
+        >;
+
+        value() : data_(nullptr) {}
+        value(std::nullptr_t) : data_(nullptr) {}
+        value(bool b) : data_(b) {}
+        value(int n) : data_(static_cast<double>(n)) {}
+        value(double n) : data_(n) {}
+        value(const char* s) : data_(std::string(s)) {}
+        value(std::string s) : data_(std::move(s)) {}
+        value(array a) : data_(std::move(a)) {}
+        value(object o) : data_(std::move(o)) {}
+
+        [[nodiscard]] auto is_null() const -> bool { return std::holds_alternative<std::nullptr_t>(data_); }
+        [[nodiscard]] auto is_bool() const -> bool { return std::holds_alternative<bool>(data_); }
+        [[nodiscard]] auto is_number() const -> bool { return std::holds_alternative<double>(data_); }
+        [[nodiscard]] auto is_string() const -> bool { return std::holds_alternative<std::string>(data_); }
+        [[nodiscard]] auto is_array() const -> bool { return std::holds_alternative<array>(data_); }
+        [[nodiscard]] auto is_object() const -> bool { return std::holds_alternative<object>(data_); }
+
+        [[nodiscard]] auto as_bool() const -> bool { return std::get<bool>(data_); }
+        [[nodiscard]] auto as_number() const -> double { return std::get<double>(data_); }
+        [[nodiscard]] auto as_int() const -> int { return static_cast<int>(std::get<double>(data_)); }
+        [[nodiscard]] auto as_string() const -> const std::string& { return std::get<std::string>(data_); }
+        [[nodiscard]] auto as_array() const -> const array& { return std::get<array>(data_); }
+        [[nodiscard]] auto as_array() -> array& { return std::get<array>(data_); }
+        [[nodiscard]] auto as_object() const -> const object& { return std::get<object>(data_); }
+        [[nodiscard]] auto as_object() -> object& { return std::get<object>(data_); }
+
+        [[nodiscard]] auto operator[](const std::string& key) const -> const value& {
+            static const value null_value;
+            if (!is_object()) return null_value;
+            auto& obj = as_object();
+            auto it = obj.find(key);
+            return it != obj.end() ? it->second : null_value;
+        }
+
+        [[nodiscard]] auto operator[](std::size_t index) const -> const value& {
+            return as_array().at(index);
+        }
+
+        [[nodiscard]] auto get(const std::string& key, const value& default_val = value()) const -> const value& {
+            if (!is_object()) return default_val;
+            auto& obj = as_object();
+            auto it = obj.find(key);
+            return it != obj.end() ? it->second : default_val;
+        }
+
+        [[nodiscard]] auto contains(const std::string& key) const -> bool {
+            if (!is_object()) return false;
+            return as_object().count(key) > 0;
+        }
+
+        [[nodiscard]] auto size() const -> std::size_t {
+            if (is_array()) return as_array().size();
+            if (is_object()) return as_object().size();
+            return 0;
+        }
+
+    private:
+        variant_type data_;
+    };
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // JSON Parser
+    // ─────────────────────────────────────────────────────────────────────────────
+
+    class parser {
+        std::string_view input_;
+        std::size_t pos_ = 0;
+
+    public:
+        [[nodiscard]] auto parse(std::string_view input) -> value {
+            input_ = input;
+            pos_ = 0;
+            skip_ws();
+            auto result = parse_value();
+            return result;
+        }
+
+    private:
+        [[nodiscard]] auto parse_value() -> value {
+            skip_ws();
+            if (pos_ >= input_.size()) return {};
+
+            char c = input_[pos_];
+            if (c == '"') return parse_string();
+            if (c == '{') return parse_object();
+            if (c == '[') return parse_array();
+            if (c == 't' || c == 'f') return parse_bool();
+            if (c == 'n') return parse_null();
+            if (c == '-' || std::isdigit(static_cast<unsigned char>(c))) return parse_number();
+
+            throw std::runtime_error("Unexpected character in JSON at position " + std::to_string(pos_));
+        }
+
+        [[nodiscard]] auto parse_string() -> value {
+            return value(read_string());
+        }
+
+        [[nodiscard]] auto read_string() -> std::string {
+            expect('"');
+            std::string result;
+            while (pos_ < input_.size() && input_[pos_] != '"') {
+                if (input_[pos_] == '\\') {
+                    ++pos_;
+                    if (pos_ >= input_.size()) break;
+                    switch (input_[pos_]) {
+                        case '"': result += '"'; break;
+                        case '\\': result += '\\'; break;
+                        case '/': result += '/'; break;
+                        case 'b': result += '\b'; break;
+                        case 'f': result += '\f'; break;
+                        case 'n': result += '\n'; break;
+                        case 'r': result += '\r'; break;
+                        case 't': result += '\t'; break;
+                        case 'u': {
+                            ++pos_;
+                            // Read 4 hex digits
+                            std::string hex;
+                            for (int i = 0; i < 4 && pos_ < input_.size(); ++i) {
+                                hex += input_[pos_++];
+                            }
+                            --pos_;  // will be incremented below
+                            auto code = static_cast<char>(std::stoi(hex, nullptr, 16));
+                            result += code;
+                            break;
+                        }
+                        default: result += input_[pos_]; break;
+                    }
+                } else {
+                    result += input_[pos_];
+                }
+                ++pos_;
+            }
+            expect('"');
+            return result;
+        }
+
+        [[nodiscard]] auto parse_number() -> value {
+            auto start = pos_;
+            if (input_[pos_] == '-') ++pos_;
+            while (pos_ < input_.size() && std::isdigit(static_cast<unsigned char>(input_[pos_]))) ++pos_;
+            if (pos_ < input_.size() && input_[pos_] == '.') {
+                ++pos_;
+                while (pos_ < input_.size() && std::isdigit(static_cast<unsigned char>(input_[pos_]))) ++pos_;
+            }
+            if (pos_ < input_.size() && (input_[pos_] == 'e' || input_[pos_] == 'E')) {
+                ++pos_;
+                if (pos_ < input_.size() && (input_[pos_] == '+' || input_[pos_] == '-')) ++pos_;
+                while (pos_ < input_.size() && std::isdigit(static_cast<unsigned char>(input_[pos_]))) ++pos_;
+            }
+            auto num_str = std::string(input_.substr(start, pos_ - start));
+            return value(std::stod(num_str));
+        }
+
+        [[nodiscard]] auto parse_bool() -> value {
+            if (input_.substr(pos_, 4) == "true") { pos_ += 4; return value(true); }
+            if (input_.substr(pos_, 5) == "false") { pos_ += 5; return value(false); }
+            throw std::runtime_error("Invalid boolean at position " + std::to_string(pos_));
+        }
+
+        [[nodiscard]] auto parse_null() -> value {
+            if (input_.substr(pos_, 4) == "null") { pos_ += 4; return value(nullptr); }
+            throw std::runtime_error("Invalid null at position " + std::to_string(pos_));
+        }
+
+        [[nodiscard]] auto parse_object() -> value {
+            expect('{');
+            skip_ws();
+            object obj;
+            if (pos_ < input_.size() && input_[pos_] == '}') { ++pos_; return value(std::move(obj)); }
+
+            while (true) {
+                skip_ws();
+                auto key = read_string();
+                skip_ws();
+                expect(':');
+                skip_ws();
+                obj[key] = parse_value();
+                skip_ws();
+                if (pos_ < input_.size() && input_[pos_] == ',') { ++pos_; continue; }
+                break;
+            }
+            skip_ws();
+            expect('}');
+            return value(std::move(obj));
+        }
+
+        [[nodiscard]] auto parse_array() -> value {
+            expect('[');
+            skip_ws();
+            array arr;
+            if (pos_ < input_.size() && input_[pos_] == ']') { ++pos_; return value(std::move(arr)); }
+
+            while (true) {
+                skip_ws();
+                arr.push_back(parse_value());
+                skip_ws();
+                if (pos_ < input_.size() && input_[pos_] == ',') { ++pos_; continue; }
+                break;
+            }
+            skip_ws();
+            expect(']');
+            return value(std::move(arr));
+        }
+
+        void skip_ws() {
+            while (pos_ < input_.size() && std::isspace(static_cast<unsigned char>(input_[pos_]))) ++pos_;
+        }
+
+        void expect(char c) {
+            if (pos_ >= input_.size() || input_[pos_] != c) {
+                throw std::runtime_error(std::string("Expected '") + c + "' at position " + std::to_string(pos_));
+            }
+            ++pos_;
+        }
+    };
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // JSON Emitter
+    // ─────────────────────────────────────────────────────────────────────────────
+
+    class emitter {
+    public:
+        [[nodiscard]] auto emit(const value& v, int indent = 0) const -> std::string {
+            std::ostringstream out;
+            write_value(out, v, indent, 0);
+            out << '\n';
+            return out.str();
+        }
+
+    private:
+        void write_value(std::ostringstream& out, const value& v, int indent, int depth) const {
+            if (v.is_null()) { out << "null"; return; }
+            if (v.is_bool()) { out << (v.as_bool() ? "true" : "false"); return; }
+            if (v.is_number()) { write_number(out, v.as_number()); return; }
+            if (v.is_string()) { write_string(out, v.as_string()); return; }
+            if (v.is_array()) { write_array(out, v.as_array(), indent, depth); return; }
+            if (v.is_object()) { write_object(out, v.as_object(), indent, depth); return; }
+        }
+
+        void write_number(std::ostringstream& out, double n) const {
+            if (n == std::floor(n) && std::abs(n) < 1e15) {
+                out << static_cast<long long>(n);
+            } else {
+                out << std::setprecision(17) << n;
+            }
+        }
+
+        void write_string(std::ostringstream& out, const std::string& s) const {
+            out << '"';
+            for (char c : s) {
+                switch (c) {
+                    case '"': out << "\\\""; break;
+                    case '\\': out << "\\\\"; break;
+                    case '\b': out << "\\b"; break;
+                    case '\f': out << "\\f"; break;
+                    case '\n': out << "\\n"; break;
+                    case '\r': out << "\\r"; break;
+                    case '\t': out << "\\t"; break;
+                    default:
+                        if (static_cast<unsigned char>(c) < 0x20) {
+                            out << "\\u" << std::hex << std::setw(4) << std::setfill('0') << static_cast<int>(c) << std::dec;
+                        } else {
+                            out << c;
+                        }
+                }
+            }
+            out << '"';
+        }
+
+        void write_array(std::ostringstream& out, const array& arr, int indent, int depth) const {
+            if (arr.empty()) { out << "[]"; return; }
+
+            // Use compact format for small arrays of numbers
+            bool all_simple = arr.size() <= 8;
+            for (const auto& v : arr) {
+                if (!v.is_number() && !v.is_bool() && !v.is_null()) { all_simple = false; break; }
+            }
+
+            if (all_simple) {
+                out << "[";
+                for (std::size_t i = 0; i < arr.size(); ++i) {
+                    if (i > 0) out << ", ";
+                    write_value(out, arr[i], indent, depth + 1);
+                }
+                out << "]";
+                return;
+            }
+
+            out << "[\n";
+            for (std::size_t i = 0; i < arr.size(); ++i) {
+                write_indent(out, indent, depth + 1);
+                write_value(out, arr[i], indent, depth + 1);
+                if (i + 1 < arr.size()) out << ",";
+                out << "\n";
+            }
+            write_indent(out, indent, depth);
+            out << "]";
+        }
+
+        void write_object(std::ostringstream& out, const object& obj, int indent, int depth) const {
+            if (obj.empty()) { out << "{}"; return; }
+
+            out << "{\n";
+            auto it = obj.begin();
+            while (it != obj.end()) {
+                write_indent(out, indent, depth + 1);
+                write_string(out, it->first);
+                out << ": ";
+                write_value(out, it->second, indent, depth + 1);
+                ++it;
+                if (it != obj.end()) out << ",";
+                out << "\n";
+            }
+            write_indent(out, indent, depth);
+            out << "}";
+        }
+
+        void write_indent(std::ostringstream& out, int indent, int depth) const {
+            for (int i = 0; i < indent * depth; ++i) out << ' ';
+        }
+    };
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Convenience functions
+    // ─────────────────────────────────────────────────────────────────────────────
+
+    [[nodiscard]] inline auto parse(std::string_view input) -> value {
+        parser p;
+        return p.parse(input);
+    }
+
+    [[nodiscard]] inline auto stringify(const value& v, int indent = 2) -> std::string {
+        emitter e;
+        return e.emit(v, indent);
+    }
+
+} // namespace oc::json

--- a/tools/liboc/oc_metadata.hpp
+++ b/tools/liboc/oc_metadata.hpp
@@ -1,0 +1,426 @@
+//
+// Open Controls - OC Metadata Format Reader/Writer
+//
+// Copyright (C) 2026 Daher Alfawares
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+
+#pragma once
+
+#include "oc_json.hpp"
+#include <string>
+#include <vector>
+#include <map>
+#include <fstream>
+
+namespace oc::metadata {
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Metadata Structures
+    // ─────────────────────────────────────────────────────────────────────────────
+
+    struct model_info {
+        std::string uuid;
+        std::string library_type;
+        std::string name;
+    };
+
+    struct port_property {
+        std::string port_type;
+        int index = 0;
+        std::map<std::string, std::string> properties;
+    };
+
+    struct mask_param {
+        std::string name;
+        std::string type;
+        std::string prompt;
+        std::string value;
+        std::string show_tooltip;
+    };
+
+    struct block_meta {
+        std::string sid;
+        std::string type;
+        std::string name;
+        std::vector<int> position;
+        int zorder = 0;
+        std::string background_color;
+        std::string subsystem_ref;
+        int port_in = 0;
+        int port_out = 0;
+        std::map<std::string, std::string> parameters;
+        std::vector<mask_param> mask_parameters;
+        std::vector<port_property> port_properties;
+        std::string mask_display_xml;
+    };
+
+    struct branch_meta {
+        int zorder = 0;
+        std::string destination;
+        std::vector<int> points;
+    };
+
+    struct connection_meta {
+        std::string name;
+        int zorder = 0;
+        std::string source;
+        std::string destination;
+        std::vector<int> points;
+        std::vector<branch_meta> branches;
+        std::string labels;
+    };
+
+    struct system_meta {
+        std::string id;
+        std::vector<int> location;
+        int zoom_factor = 100;
+        int sid_highwatermark = 0;
+        std::string open;
+        std::string report_name;
+        std::vector<block_meta> blocks;
+        std::vector<connection_meta> connections;
+    };
+
+    struct metadata {
+        int version = 1;
+        model_info model;
+        std::vector<std::string> part_order;  // preserves original OPC part ordering
+        std::map<std::string, std::string> raw_parts;
+        std::map<std::string, system_meta> systems;
+    };
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Write metadata to JSON
+    // ─────────────────────────────────────────────────────────────────────────────
+
+    [[nodiscard]] inline auto to_json(const metadata& meta) -> json::value {
+        json::object root;
+        root["version"] = meta.version;
+
+        // Model info
+        json::object model_obj;
+        model_obj["uuid"] = meta.model.uuid;
+        model_obj["library_type"] = meta.model.library_type;
+        model_obj["name"] = meta.model.name;
+        root["model"] = json::value(std::move(model_obj));
+
+        // Part order
+        if (!meta.part_order.empty()) {
+            json::array order_arr;
+            for (const auto& p : meta.part_order) order_arr.push_back(json::value(p));
+            root["part_order"] = json::value(std::move(order_arr));
+        }
+
+        // Raw parts
+        json::object raw_obj;
+        for (const auto& [path, content] : meta.raw_parts) {
+            raw_obj[path] = content;
+        }
+        root["raw_parts"] = json::value(std::move(raw_obj));
+
+        // Systems
+        json::object systems_obj;
+        for (const auto& [sys_id, sys] : meta.systems) {
+            json::object sys_obj;
+
+            // System properties
+            {
+                json::array loc;
+                for (int v : sys.location) loc.push_back(json::value(v));
+                sys_obj["location"] = json::value(std::move(loc));
+            }
+            sys_obj["zoom_factor"] = sys.zoom_factor;
+            sys_obj["sid_highwatermark"] = sys.sid_highwatermark;
+            if (!sys.open.empty()) sys_obj["open"] = sys.open;
+            if (!sys.report_name.empty()) sys_obj["report_name"] = sys.report_name;
+
+            // Blocks
+            json::array blocks_arr;
+            for (const auto& blk : sys.blocks) {
+                json::object blk_obj;
+                blk_obj["sid"] = blk.sid;
+                blk_obj["type"] = blk.type;
+                blk_obj["name"] = blk.name;
+
+                {
+                    json::array pos;
+                    for (int v : blk.position) pos.push_back(json::value(v));
+                    blk_obj["position"] = json::value(std::move(pos));
+                }
+
+                blk_obj["zorder"] = blk.zorder;
+                if (!blk.background_color.empty()) blk_obj["background_color"] = blk.background_color;
+                if (!blk.subsystem_ref.empty()) blk_obj["subsystem_ref"] = blk.subsystem_ref;
+                if (blk.port_in > 0) blk_obj["port_in"] = blk.port_in;
+                if (blk.port_out > 0) blk_obj["port_out"] = blk.port_out;
+
+                // Parameters
+                if (!blk.parameters.empty()) {
+                    json::object params;
+                    for (const auto& [k, v] : blk.parameters) params[k] = v;
+                    blk_obj["parameters"] = json::value(std::move(params));
+                }
+
+                // Mask parameters
+                if (!blk.mask_parameters.empty()) {
+                    json::array mask_arr;
+                    for (const auto& mp : blk.mask_parameters) {
+                        json::object mp_obj;
+                        mp_obj["name"] = mp.name;
+                        mp_obj["type"] = mp.type;
+                        mp_obj["prompt"] = mp.prompt;
+                        mp_obj["value"] = mp.value;
+                        if (!mp.show_tooltip.empty()) mp_obj["show_tooltip"] = mp.show_tooltip;
+                        mask_arr.push_back(json::value(std::move(mp_obj)));
+                    }
+                    blk_obj["mask"] = json::value(std::move(mask_arr));
+                }
+                if (!blk.mask_display_xml.empty()) {
+                    blk_obj["mask_display_xml"] = blk.mask_display_xml;
+                }
+
+                // Port properties
+                if (!blk.port_properties.empty()) {
+                    json::array pp_arr;
+                    for (const auto& pp : blk.port_properties) {
+                        json::object pp_obj;
+                        pp_obj["port_type"] = pp.port_type;
+                        pp_obj["index"] = pp.index;
+                        json::object props;
+                        for (const auto& [k, v] : pp.properties) props[k] = v;
+                        pp_obj["properties"] = json::value(std::move(props));
+                        pp_arr.push_back(json::value(std::move(pp_obj)));
+                    }
+                    blk_obj["port_properties"] = json::value(std::move(pp_arr));
+                }
+
+                blocks_arr.push_back(json::value(std::move(blk_obj)));
+            }
+            sys_obj["blocks"] = json::value(std::move(blocks_arr));
+
+            // Connections
+            json::array conns_arr;
+            for (const auto& conn : sys.connections) {
+                json::object conn_obj;
+                if (!conn.name.empty()) conn_obj["name"] = conn.name;
+                conn_obj["zorder"] = conn.zorder;
+                conn_obj["src"] = conn.source;
+                if (!conn.destination.empty()) conn_obj["dst"] = conn.destination;
+                if (!conn.labels.empty()) conn_obj["labels"] = conn.labels;
+
+                if (!conn.points.empty()) {
+                    json::array pts;
+                    for (int v : conn.points) pts.push_back(json::value(v));
+                    conn_obj["points"] = json::value(std::move(pts));
+                }
+
+                if (!conn.branches.empty()) {
+                    json::array br_arr;
+                    for (const auto& br : conn.branches) {
+                        json::object br_obj;
+                        br_obj["zorder"] = br.zorder;
+                        br_obj["dst"] = br.destination;
+                        if (!br.points.empty()) {
+                            json::array pts;
+                            for (int v : br.points) pts.push_back(json::value(v));
+                            br_obj["points"] = json::value(std::move(pts));
+                        }
+                        br_arr.push_back(json::value(std::move(br_obj)));
+                    }
+                    conn_obj["branches"] = json::value(std::move(br_arr));
+                }
+
+                conns_arr.push_back(json::value(std::move(conn_obj)));
+            }
+            sys_obj["connections"] = json::value(std::move(conns_arr));
+
+            systems_obj[sys_id] = json::value(std::move(sys_obj));
+        }
+        root["systems"] = json::value(std::move(systems_obj));
+
+        return json::value(std::move(root));
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Read metadata from JSON
+    // ─────────────────────────────────────────────────────────────────────────────
+
+    namespace detail {
+        [[nodiscard]] inline auto parse_int_array(const json::value& v) -> std::vector<int> {
+            std::vector<int> result;
+            if (v.is_array()) {
+                for (const auto& item : v.as_array()) {
+                    result.push_back(item.as_int());
+                }
+            }
+            return result;
+        }
+
+        [[nodiscard]] inline auto get_string(const json::value& v, const std::string& key) -> std::string {
+            if (v.contains(key) && v[key].is_string()) return v[key].as_string();
+            return {};
+        }
+
+        [[nodiscard]] inline auto get_int(const json::value& v, const std::string& key, int def = 0) -> int {
+            if (v.contains(key) && v[key].is_number()) return v[key].as_int();
+            return def;
+        }
+    }
+
+    [[nodiscard]] inline auto from_json(const json::value& root) -> metadata {
+        metadata meta;
+        meta.version = detail::get_int(root, "version", 1);
+
+        // Model info
+        if (root.contains("model")) {
+            const auto& m = root["model"];
+            meta.model.uuid = detail::get_string(m, "uuid");
+            meta.model.library_type = detail::get_string(m, "library_type");
+            meta.model.name = detail::get_string(m, "name");
+        }
+
+        // Part order
+        if (root.contains("part_order") && root["part_order"].is_array()) {
+            for (const auto& item : root["part_order"].as_array()) {
+                if (item.is_string()) meta.part_order.push_back(item.as_string());
+            }
+        }
+
+        // Raw parts
+        if (root.contains("raw_parts") && root["raw_parts"].is_object()) {
+            for (const auto& [path, content] : root["raw_parts"].as_object()) {
+                if (content.is_string()) meta.raw_parts[path] = content.as_string();
+            }
+        }
+
+        // Systems
+        if (root.contains("systems") && root["systems"].is_object()) {
+            for (const auto& [sys_id, sys_val] : root["systems"].as_object()) {
+                system_meta sys;
+                sys.id = sys_id;
+                sys.location = detail::parse_int_array(sys_val["location"]);
+                sys.zoom_factor = detail::get_int(sys_val, "zoom_factor", 100);
+                sys.sid_highwatermark = detail::get_int(sys_val, "sid_highwatermark");
+                sys.open = detail::get_string(sys_val, "open");
+                sys.report_name = detail::get_string(sys_val, "report_name");
+
+                // Blocks
+                if (sys_val.contains("blocks") && sys_val["blocks"].is_array()) {
+                    for (const auto& blk_val : sys_val["blocks"].as_array()) {
+                        block_meta blk;
+                        blk.sid = detail::get_string(blk_val, "sid");
+                        blk.type = detail::get_string(blk_val, "type");
+                        blk.name = detail::get_string(blk_val, "name");
+                        blk.position = detail::parse_int_array(blk_val["position"]);
+                        blk.zorder = detail::get_int(blk_val, "zorder");
+                        blk.background_color = detail::get_string(blk_val, "background_color");
+                        blk.subsystem_ref = detail::get_string(blk_val, "subsystem_ref");
+                        blk.port_in = detail::get_int(blk_val, "port_in");
+                        blk.port_out = detail::get_int(blk_val, "port_out");
+                        blk.mask_display_xml = detail::get_string(blk_val, "mask_display_xml");
+
+                        // Parameters
+                        if (blk_val.contains("parameters") && blk_val["parameters"].is_object()) {
+                            for (const auto& [k, v] : blk_val["parameters"].as_object()) {
+                                if (v.is_string()) blk.parameters[k] = v.as_string();
+                            }
+                        }
+
+                        // Mask parameters
+                        if (blk_val.contains("mask") && blk_val["mask"].is_array()) {
+                            for (const auto& mp_val : blk_val["mask"].as_array()) {
+                                mask_param mp;
+                                mp.name = detail::get_string(mp_val, "name");
+                                mp.type = detail::get_string(mp_val, "type");
+                                mp.prompt = detail::get_string(mp_val, "prompt");
+                                mp.value = detail::get_string(mp_val, "value");
+                                mp.show_tooltip = detail::get_string(mp_val, "show_tooltip");
+                                blk.mask_parameters.push_back(std::move(mp));
+                            }
+                        }
+
+                        // Port properties
+                        if (blk_val.contains("port_properties") && blk_val["port_properties"].is_array()) {
+                            for (const auto& pp_val : blk_val["port_properties"].as_array()) {
+                                port_property pp;
+                                pp.port_type = detail::get_string(pp_val, "port_type");
+                                pp.index = detail::get_int(pp_val, "index");
+                                if (pp_val.contains("properties") && pp_val["properties"].is_object()) {
+                                    for (const auto& [k, v] : pp_val["properties"].as_object()) {
+                                        if (v.is_string()) pp.properties[k] = v.as_string();
+                                    }
+                                }
+                                blk.port_properties.push_back(std::move(pp));
+                            }
+                        }
+
+                        sys.blocks.push_back(std::move(blk));
+                    }
+                }
+
+                // Connections
+                if (sys_val.contains("connections") && sys_val["connections"].is_array()) {
+                    for (const auto& conn_val : sys_val["connections"].as_array()) {
+                        connection_meta conn;
+                        conn.name = detail::get_string(conn_val, "name");
+                        conn.zorder = detail::get_int(conn_val, "zorder");
+                        conn.source = detail::get_string(conn_val, "src");
+                        conn.destination = detail::get_string(conn_val, "dst");
+                        conn.labels = detail::get_string(conn_val, "labels");
+                        conn.points = detail::parse_int_array(conn_val["points"]);
+
+                        // Branches
+                        if (conn_val.contains("branches") && conn_val["branches"].is_array()) {
+                            for (const auto& br_val : conn_val["branches"].as_array()) {
+                                branch_meta br;
+                                br.zorder = detail::get_int(br_val, "zorder");
+                                br.destination = detail::get_string(br_val, "dst");
+                                br.points = detail::parse_int_array(br_val["points"]);
+                                conn.branches.push_back(std::move(br));
+                            }
+                        }
+
+                        sys.connections.push_back(std::move(conn));
+                    }
+                }
+
+                meta.systems[sys_id] = std::move(sys);
+            }
+        }
+
+        return meta;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // File I/O
+    // ─────────────────────────────────────────────────────────────────────────────
+
+    [[nodiscard]] inline auto write_file(const std::string& path, const metadata& meta) -> bool {
+        auto json_val = to_json(meta);
+        auto json_str = json::stringify(json_val, 2);
+
+        std::ofstream out(path);
+        if (!out) return false;
+        out << json_str;
+        return out.good();
+    }
+
+    [[nodiscard]] inline auto read_file(const std::string& path) -> std::optional<metadata> {
+        std::ifstream in(path);
+        if (!in) return std::nullopt;
+
+        std::string content{std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>()};
+        try {
+            auto json_val = json::parse(content);
+            return from_json(json_val);
+        } catch (...) {
+            return std::nullopt;
+        }
+    }
+
+} // namespace oc::metadata

--- a/tools/liboc/oc_parser.hpp
+++ b/tools/liboc/oc_parser.hpp
@@ -1,0 +1,644 @@
+//
+// Open Controls - OC Format Parser
+//
+// Copyright (C) 2026 Daher Alfawares
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+
+#pragma once
+
+#include <string>
+#include <string_view>
+#include <vector>
+#include <optional>
+#include <sstream>
+#include <stdexcept>
+#include <cctype>
+
+namespace oc::parser {
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // AST Types
+    // ─────────────────────────────────────────────────────────────────────────────
+
+    struct oc_var_decl {
+        std::string type;
+        std::string name;
+        std::string default_value;
+        std::string comment;
+    };
+
+    struct oc_section {
+        std::string kind;  // "input", "output", "state", "config"
+        std::vector<oc_var_decl> variables;
+    };
+
+    struct oc_update_body {
+        std::string raw_code;
+    };
+
+    struct oc_component {
+        std::string name;
+        std::vector<oc_section> sections;
+        oc_update_body update;
+    };
+
+    struct oc_element {
+        std::string name;
+        std::string frequency;
+        std::vector<oc_section> sections;
+        oc_update_body update;
+    };
+
+    struct oc_namespace {
+        std::string name;
+        std::vector<oc_element> elements;
+        std::vector<oc_component> components;
+    };
+
+    struct oc_file {
+        std::vector<oc_namespace> namespaces;
+    };
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Parse Error
+    // ─────────────────────────────────────────────────────────────────────────────
+
+    struct parse_error {
+        int line = 0;
+        int column = 0;
+        std::string message;
+
+        [[nodiscard]] auto to_string() const -> std::string {
+            return std::to_string(line) + ":" + std::to_string(column) + ": " + message;
+        }
+    };
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Token Types
+    // ─────────────────────────────────────────────────────────────────────────────
+
+    enum class token_type {
+        // Keywords
+        kw_namespace, kw_element, kw_component, kw_controller,
+        kw_input, kw_output, kw_state, kw_config, kw_memory,
+        kw_update, kw_operation, kw_frequency,
+        // Types
+        ty_float, ty_int, ty_auto,
+        // Literals
+        identifier, number, string_literal,
+        // Punctuation
+        lbrace, rbrace, lparen, rparen, semicolon, comma, colon,
+        // Operators
+        op_assign, op_dot, op_scope,
+        // Special
+        comment, eof
+    };
+
+    struct token {
+        token_type type = token_type::eof;
+        std::string text;
+        int line = 0;
+        int column = 0;
+    };
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Lexer
+    // ─────────────────────────────────────────────────────────────────────────────
+
+    class lexer {
+        std::string_view input_;
+        std::size_t pos_ = 0;
+        int line_ = 1;
+        int col_ = 1;
+
+    public:
+        explicit lexer(std::string_view input) : input_(input) {}
+
+        [[nodiscard]] auto tokenize() -> std::vector<token> {
+            std::vector<token> tokens;
+            while (pos_ < input_.size()) {
+                skip_whitespace();
+                if (pos_ >= input_.size()) break;
+
+                auto tok = next_token();
+                if (tok.type == token_type::comment) continue;  // skip comments
+                tokens.push_back(std::move(tok));
+            }
+            tokens.push_back({token_type::eof, "", line_, col_});
+            return tokens;
+        }
+
+    private:
+        [[nodiscard]] auto next_token() -> token {
+            int start_line = line_;
+            int start_col = col_;
+            char c = input_[pos_];
+
+            // Single-line comment
+            if (c == '/' && pos_ + 1 < input_.size() && input_[pos_ + 1] == '/') {
+                auto start = pos_;
+                while (pos_ < input_.size() && input_[pos_] != '\n') advance();
+                return {token_type::comment, std::string(input_.substr(start, pos_ - start)), start_line, start_col};
+            }
+
+            // String literal
+            if (c == '"') {
+                advance();
+                auto start = pos_;
+                while (pos_ < input_.size() && input_[pos_] != '"') {
+                    if (input_[pos_] == '\\' && pos_ + 1 < input_.size()) advance();
+                    advance();
+                }
+                auto text = std::string(input_.substr(start, pos_ - start));
+                if (pos_ < input_.size()) advance();  // skip closing quote
+                return {token_type::string_literal, text, start_line, start_col};
+            }
+
+            // Punctuation
+            if (c == '{') { advance(); return {token_type::lbrace, "{", start_line, start_col}; }
+            if (c == '}') { advance(); return {token_type::rbrace, "}", start_line, start_col}; }
+            if (c == '(') { advance(); return {token_type::lparen, "(", start_line, start_col}; }
+            if (c == ')') { advance(); return {token_type::rparen, ")", start_line, start_col}; }
+            if (c == ';') { advance(); return {token_type::semicolon, ";", start_line, start_col}; }
+            if (c == ',') { advance(); return {token_type::comma, ",", start_line, start_col}; }
+            if (c == '=') { advance(); return {token_type::op_assign, "=", start_line, start_col}; }
+            if (c == '.') { advance(); return {token_type::op_dot, ".", start_line, start_col}; }
+
+            if (c == ':') {
+                if (pos_ + 1 < input_.size() && input_[pos_ + 1] == ':') {
+                    advance(); advance();
+                    return {token_type::op_scope, "::", start_line, start_col};
+                }
+                advance();
+                return {token_type::colon, ":", start_line, start_col};
+            }
+
+            // Number
+            if (std::isdigit(static_cast<unsigned char>(c)) || (c == '-' && pos_ + 1 < input_.size() && std::isdigit(static_cast<unsigned char>(input_[pos_ + 1])))) {
+                auto start = pos_;
+                if (c == '-') advance();
+                while (pos_ < input_.size() && (std::isdigit(static_cast<unsigned char>(input_[pos_])) || input_[pos_] == '.')) advance();
+                // Handle scientific notation
+                if (pos_ < input_.size() && (input_[pos_] == 'e' || input_[pos_] == 'E')) {
+                    advance();
+                    if (pos_ < input_.size() && (input_[pos_] == '+' || input_[pos_] == '-')) advance();
+                    while (pos_ < input_.size() && std::isdigit(static_cast<unsigned char>(input_[pos_]))) advance();
+                }
+                // Handle float suffix
+                if (pos_ < input_.size() && (input_[pos_] == 'f' || input_[pos_] == 'F')) advance();
+                return {token_type::number, std::string(input_.substr(start, pos_ - start)), start_line, start_col};
+            }
+
+            // Identifier or keyword
+            if (std::isalpha(static_cast<unsigned char>(c)) || c == '_') {
+                auto start = pos_;
+                while (pos_ < input_.size() && (std::isalnum(static_cast<unsigned char>(input_[pos_])) || input_[pos_] == '_')) advance();
+                auto text = std::string(input_.substr(start, pos_ - start));
+
+                auto type = classify_keyword(text);
+                return {type, std::move(text), start_line, start_col};
+            }
+
+            // Unknown character — consume and return as identifier
+            advance();
+            return {token_type::identifier, std::string(1, c), start_line, start_col};
+        }
+
+        void skip_whitespace() {
+            while (pos_ < input_.size()) {
+                char c = input_[pos_];
+                if (c == ' ' || c == '\t' || c == '\r') {
+                    advance();
+                } else if (c == '\n') {
+                    advance();
+                } else {
+                    break;
+                }
+            }
+        }
+
+        void advance() {
+            if (pos_ < input_.size()) {
+                if (input_[pos_] == '\n') { ++line_; col_ = 1; }
+                else { ++col_; }
+                ++pos_;
+            }
+        }
+
+        [[nodiscard]] static auto classify_keyword(const std::string& text) -> token_type {
+            if (text == "namespace")  return token_type::kw_namespace;
+            if (text == "element")    return token_type::kw_element;
+            if (text == "component")  return token_type::kw_component;
+            if (text == "controller") return token_type::kw_controller;
+            if (text == "input")      return token_type::kw_input;
+            if (text == "output")     return token_type::kw_output;
+            if (text == "state")      return token_type::kw_state;
+            if (text == "config")     return token_type::kw_config;
+            if (text == "memory")     return token_type::kw_memory;
+            if (text == "update")     return token_type::kw_update;
+            if (text == "operation")  return token_type::kw_operation;
+            if (text == "frequency")  return token_type::kw_frequency;
+            if (text == "float")      return token_type::ty_float;
+            if (text == "int")        return token_type::ty_int;
+            if (text == "auto")       return token_type::ty_auto;
+            return token_type::identifier;
+        }
+    };
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Parser — Recursive Descent
+    // ─────────────────────────────────────────────────────────────────────────────
+
+    class oc_parser {
+        std::vector<token> tokens_;
+        std::size_t pos_ = 0;
+        std::vector<parse_error> errors_;
+        std::string_view source_;  // original source for raw code extraction
+
+    public:
+        [[nodiscard]] auto parse(std::string_view source) -> oc_file {
+            source_ = source;
+            lexer lex(source);
+            tokens_ = lex.tokenize();
+            pos_ = 0;
+            errors_.clear();
+
+            oc_file file;
+            while (!at_end()) {
+                if (check(token_type::kw_namespace)) {
+                    file.namespaces.push_back(parse_namespace());
+                } else {
+                    error("Expected 'namespace' at top level");
+                    advance();
+                }
+            }
+            return file;
+        }
+
+        [[nodiscard]] auto has_errors() const -> bool { return !errors_.empty(); }
+        [[nodiscard]] auto get_errors() const -> const std::vector<parse_error>& { return errors_; }
+
+    private:
+        // ─── Namespace ──────────────────────────────────────────────────────
+        [[nodiscard]] auto parse_namespace() -> oc_namespace {
+            oc_namespace ns;
+            expect(token_type::kw_namespace);
+            ns.name = expect_identifier();
+            expect(token_type::lbrace);
+
+            while (!check(token_type::rbrace) && !at_end()) {
+                if (check(token_type::kw_element)) {
+                    ns.elements.push_back(parse_element());
+                } else if (check(token_type::kw_component)) {
+                    ns.components.push_back(parse_component());
+                } else if (check(token_type::kw_controller)) {
+                    // Skip controller blocks for now — just brace-match
+                    advance();
+                    skip_identifier();
+                    skip_brace_block();
+                } else {
+                    error("Expected 'element', 'component', or 'controller' inside namespace");
+                    advance();
+                }
+            }
+            expect(token_type::rbrace);
+            return ns;
+        }
+
+        // ─── Element ────────────────────────────────────────────────────────
+        [[nodiscard]] auto parse_element() -> oc_element {
+            oc_element elem;
+            expect(token_type::kw_element);
+            elem.name = expect_identifier();
+            expect(token_type::lbrace);
+
+            while (!check(token_type::rbrace) && !at_end()) {
+                if (check(token_type::kw_frequency)) {
+                    elem.frequency = parse_frequency();
+                } else if (check(token_type::kw_input) || check(token_type::kw_output) ||
+                           check(token_type::kw_state) || check(token_type::kw_config) ||
+                           check(token_type::kw_memory)) {
+                    elem.sections.push_back(parse_section());
+                } else if (check(token_type::kw_update) || check(token_type::kw_operation)) {
+                    elem.update = parse_update();
+                } else {
+                    error("Unexpected token in element body");
+                    advance();
+                }
+            }
+            expect(token_type::rbrace);
+            return elem;
+        }
+
+        // ─── Component ──────────────────────────────────────────────────────
+        [[nodiscard]] auto parse_component() -> oc_component {
+            oc_component comp;
+            expect(token_type::kw_component);
+            comp.name = expect_identifier();
+            expect(token_type::lbrace);
+
+            while (!check(token_type::rbrace) && !at_end()) {
+                if (check(token_type::kw_input) || check(token_type::kw_output) ||
+                    check(token_type::kw_state) || check(token_type::kw_config) ||
+                    check(token_type::kw_memory)) {
+                    comp.sections.push_back(parse_section());
+                } else if (check(token_type::kw_update) || check(token_type::kw_operation)) {
+                    comp.update = parse_update();
+                } else {
+                    error("Unexpected token in component body");
+                    advance();
+                }
+            }
+            expect(token_type::rbrace);
+            return comp;
+        }
+
+        // ─── Frequency ──────────────────────────────────────────────────────
+        [[nodiscard]] auto parse_frequency() -> std::string {
+            expect(token_type::kw_frequency);
+            // May have optional colon
+            if (check(token_type::colon)) advance();
+
+            // Collect everything until semicolon or newline-like break
+            std::string freq;
+            while (!check(token_type::semicolon) && !check(token_type::rbrace) &&
+                   !check(token_type::kw_input) && !check(token_type::kw_output) &&
+                   !check(token_type::kw_state) && !check(token_type::kw_config) &&
+                   !check(token_type::kw_update) && !check(token_type::kw_operation) &&
+                   !at_end()) {
+                if (!freq.empty()) freq += " ";
+                freq += current().text;
+                advance();
+            }
+            if (check(token_type::semicolon)) advance();
+            return freq;
+        }
+
+        // ─── Section (input/output/state/config/memory) ─────────────────────
+        [[nodiscard]] auto parse_section() -> oc_section {
+            oc_section sec;
+            sec.kind = current().text;
+            advance();
+
+            // May use '{' ... '}' or ':' style
+            if (check(token_type::lbrace)) {
+                advance();
+                while (!check(token_type::rbrace) && !at_end()) {
+                    sec.variables.push_back(parse_var_decl());
+                }
+                expect(token_type::rbrace);
+            } else if (check(token_type::colon)) {
+                advance();
+                // Colon-style: declarations until next section keyword or '}'
+                while (!is_section_keyword() && !check(token_type::rbrace) &&
+                       !check(token_type::kw_update) && !check(token_type::kw_operation) && !at_end()) {
+                    sec.variables.push_back(parse_var_decl());
+                }
+            } else {
+                // Brace block expected
+                expect(token_type::lbrace);
+            }
+            return sec;
+        }
+
+        // ─── Variable Declaration ───────────────────────────────────────────
+        [[nodiscard]] auto parse_var_decl() -> oc_var_decl {
+            oc_var_decl var;
+
+            // Type (could be a built-in type or a custom type name)
+            if (is_type_token()) {
+                var.type = current().text;
+                advance();
+            } else if (check(token_type::identifier)) {
+                var.type = current().text;
+                advance();
+            } else {
+                error("Expected type in variable declaration");
+                advance();
+                return var;
+            }
+
+            // Name
+            if (check(token_type::identifier) || is_keyword_usable_as_name()) {
+                var.name = current().text;
+                advance();
+            } else {
+                // Type might be the name in "component_name component_name;" pattern
+                // Backtrack: the "type" was actually the type, and name is next
+                error("Expected variable name after type");
+                return var;
+            }
+
+            // Optional default value
+            if (check(token_type::op_assign)) {
+                advance();
+                // Collect expression until semicolon
+                std::string expr;
+                int paren_depth = 0;
+                while (!at_end()) {
+                    if (check(token_type::semicolon) && paren_depth == 0) break;
+                    if (check(token_type::lparen)) paren_depth++;
+                    if (check(token_type::rparen)) paren_depth--;
+                    if (!expr.empty()) expr += " ";
+                    expr += current().text;
+                    advance();
+                }
+                var.default_value = expr;
+            }
+
+            if (check(token_type::semicolon)) advance();
+            return var;
+        }
+
+        // ─── Update/Operation Body ──────────────────────────────────────────
+        [[nodiscard]] auto parse_update() -> oc_update_body {
+            oc_update_body body;
+            advance();  // skip 'update' or 'operation'
+            expect(token_type::lbrace);
+
+            // Extract raw code by brace-matching
+            int depth = 1;
+            auto start_pos = pos_;
+
+            while (!at_end() && depth > 0) {
+                if (check(token_type::lbrace)) depth++;
+                if (check(token_type::rbrace)) {
+                    depth--;
+                    if (depth == 0) break;
+                }
+                advance();
+            }
+
+            // Reconstruct code from tokens between start and current
+            std::ostringstream code;
+            for (auto i = start_pos; i < pos_; ++i) {
+                // Reconstruct spacing heuristically
+                if (i > start_pos) {
+                    auto& prev = tokens_[i - 1];
+                    auto& curr = tokens_[i];
+                    if (curr.line > prev.line) {
+                        for (int l = 0; l < curr.line - prev.line; ++l) code << '\n';
+                        for (int s = 1; s < curr.column; ++s) code << ' ';
+                    } else if (curr.column > prev.column + static_cast<int>(prev.text.size())) {
+                        int spaces = curr.column - (prev.column + static_cast<int>(prev.text.size()));
+                        for (int s = 0; s < spaces; ++s) code << ' ';
+                    } else {
+                        code << ' ';
+                    }
+                } else {
+                    // Leading whitespace for first token
+                    if (!tokens_.empty() && start_pos < tokens_.size()) {
+                        auto& first = tokens_[start_pos];
+                        if (first.line > tokens_[start_pos > 0 ? start_pos - 1 : 0].line) {
+                            code << '\n';
+                            for (int s = 1; s < first.column; ++s) code << ' ';
+                        }
+                    }
+                }
+                code << tokens_[i].text;
+            }
+
+            body.raw_code = code.str();
+            expect(token_type::rbrace);
+            return body;
+        }
+
+        // ─── Helpers ────────────────────────────────────────────────────────
+        [[nodiscard]] auto current() const -> const token& { return tokens_[pos_]; }
+        [[nodiscard]] auto at_end() const -> bool { return pos_ >= tokens_.size() || tokens_[pos_].type == token_type::eof; }
+
+        [[nodiscard]] auto check(token_type type) const -> bool {
+            return !at_end() && tokens_[pos_].type == type;
+        }
+
+        void advance() {
+            if (!at_end()) ++pos_;
+        }
+
+        void expect(token_type type) {
+            if (!check(type)) {
+                error("Expected '" + token_name(type) + "', got '" + (at_end() ? "EOF" : current().text) + "'");
+                return;
+            }
+            advance();
+        }
+
+        [[nodiscard]] auto expect_identifier() -> std::string {
+            if (check(token_type::identifier)) {
+                auto text = current().text;
+                advance();
+                return text;
+            }
+            // Allow keywords to be used as identifiers in name positions
+            if (is_keyword_usable_as_name()) {
+                auto text = current().text;
+                advance();
+                return text;
+            }
+            error("Expected identifier, got '" + (at_end() ? "EOF" : current().text) + "'");
+            return "<error>";
+        }
+
+        void skip_identifier() {
+            if (check(token_type::identifier) || is_keyword_usable_as_name()) advance();
+        }
+
+        void skip_brace_block() {
+            if (!check(token_type::lbrace)) return;
+            advance();
+            int depth = 1;
+            while (!at_end() && depth > 0) {
+                if (check(token_type::lbrace)) depth++;
+                if (check(token_type::rbrace)) depth--;
+                advance();
+            }
+        }
+
+        [[nodiscard]] auto is_type_token() const -> bool {
+            return check(token_type::ty_float) || check(token_type::ty_int) || check(token_type::ty_auto);
+        }
+
+        [[nodiscard]] auto is_keyword_usable_as_name() const -> bool {
+            if (at_end()) return false;
+            auto t = tokens_[pos_].type;
+            // Allow certain keywords in name positions
+            return t == token_type::kw_input || t == token_type::kw_output ||
+                   t == token_type::kw_state || t == token_type::kw_config ||
+                   t == token_type::kw_memory;
+        }
+
+        [[nodiscard]] auto is_section_keyword() const -> bool {
+            return check(token_type::kw_input) || check(token_type::kw_output) ||
+                   check(token_type::kw_state) || check(token_type::kw_config) ||
+                   check(token_type::kw_memory) || check(token_type::kw_frequency);
+        }
+
+        void error(const std::string& msg) {
+            parse_error err;
+            if (!at_end()) {
+                err.line = current().line;
+                err.column = current().column;
+            }
+            err.message = msg;
+            errors_.push_back(std::move(err));
+        }
+
+        [[nodiscard]] static auto token_name(token_type t) -> std::string {
+            switch (t) {
+                case token_type::kw_namespace: return "namespace";
+                case token_type::kw_element: return "element";
+                case token_type::kw_component: return "component";
+                case token_type::kw_controller: return "controller";
+                case token_type::kw_input: return "input";
+                case token_type::kw_output: return "output";
+                case token_type::kw_state: return "state";
+                case token_type::kw_config: return "config";
+                case token_type::kw_memory: return "memory";
+                case token_type::kw_update: return "update";
+                case token_type::kw_operation: return "operation";
+                case token_type::kw_frequency: return "frequency";
+                case token_type::ty_float: return "float";
+                case token_type::ty_int: return "int";
+                case token_type::ty_auto: return "auto";
+                case token_type::identifier: return "identifier";
+                case token_type::number: return "number";
+                case token_type::string_literal: return "string";
+                case token_type::lbrace: return "{";
+                case token_type::rbrace: return "}";
+                case token_type::lparen: return "(";
+                case token_type::rparen: return ")";
+                case token_type::semicolon: return ";";
+                case token_type::comma: return ",";
+                case token_type::colon: return ":";
+                case token_type::op_assign: return "=";
+                case token_type::op_dot: return ".";
+                case token_type::op_scope: return "::";
+                case token_type::comment: return "comment";
+                case token_type::eof: return "EOF";
+            }
+            return "unknown";
+        }
+    };
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Convenience: load and parse a file
+    // ─────────────────────────────────────────────────────────────────────────────
+
+    struct parse_result {
+        oc_file file;
+        std::vector<parse_error> errors;
+        bool success = false;
+    };
+
+    [[nodiscard]] inline auto parse_string(std::string_view source) -> parse_result {
+        oc_parser p;
+        auto file = p.parse(source);
+        return {std::move(file), p.get_errors(), !p.has_errors()};
+    }
+
+} // namespace oc::parser

--- a/tools/mdl_to_oc/main.cpp
+++ b/tools/mdl_to_oc/main.cpp
@@ -12,6 +12,7 @@
 #include "../libmdl/oc_mdl.hpp"
 #include "../mdl_to_yaml/yaml_writer.hpp"
 #include "oc_writer.hpp"
+#include "metadata_writer.hpp"
 #include <iostream>
 #include <fstream>
 #include <filesystem>
@@ -168,6 +169,17 @@ auto main(int argc, char* argv[]) -> int {
 
     std::println("\nExported {} YAML schema(s) to {}/", yaml_exported, yaml_dir);
     std::println("Exported {} OC file(s) to {}/", oc_exported, oc_dir);
+
+    // Export metadata
+    oc::metadata_writer meta_writer;
+    auto meta = meta_writer.build_metadata(model, parser.get_opc());
+
+    auto metadata_path = fs::path(oc_dir) / (model_name + ".oc.metadata");
+    if (oc::metadata::write_file(metadata_path.string(), meta)) {
+        std::println("Exported metadata to {}", metadata_path.string());
+    } else {
+        std::println(stderr, "Error: Could not write metadata file");
+    }
 
     return 0;
 }

--- a/tools/mdl_to_oc/metadata_writer.hpp
+++ b/tools/mdl_to_oc/metadata_writer.hpp
@@ -1,0 +1,149 @@
+//
+// Open Controls - Metadata Writer (MDL → .oc.metadata)
+//
+// Copyright (C) 2026 Daher Alfawares
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+
+#pragma once
+
+#include "../libmdl/oc_mdl.hpp"
+#include "../liboc/oc_metadata.hpp"
+#include <string>
+#include <set>
+
+namespace oc {
+
+    class metadata_writer {
+    public:
+        [[nodiscard]] auto build_metadata(
+            const mdl::model& model,
+            const mdl::opc_extractor& opc) -> metadata::metadata
+        {
+            metadata::metadata meta;
+            meta.version = 1;
+
+            // Model info
+            meta.model.uuid = model.uuid;
+            meta.model.library_type = model.library_type;
+            meta.model.name = model.name;
+
+            // Capture original part ordering and ALL raw parts (including system XMLs)
+            for (const auto& path : opc.list_parts()) {
+                meta.part_order.push_back(path);
+                if (auto* content = opc.get_part(path)) {
+                    meta.raw_parts[path] = *content;
+                }
+            }
+
+            // Capture per-system metadata
+            for (const auto& [sys_id, sys] : model.systems) {
+                meta.systems[sys_id] = build_system_meta(sys);
+            }
+
+            return meta;
+        }
+
+    private:
+        [[nodiscard]] auto collect_system_paths(const mdl::opc_extractor& opc) -> std::set<std::string> {
+            std::set<std::string> paths;
+            for (const auto& path : opc.list_systems()) {
+                paths.insert(path);
+            }
+            return paths;
+        }
+
+        [[nodiscard]] auto build_system_meta(const mdl::system& sys) -> metadata::system_meta {
+            metadata::system_meta sm;
+            sm.id = sys.id;
+            sm.location = sys.location;
+            sm.zoom_factor = sys.zoom_factor;
+            sm.sid_highwatermark = sys.sid_highwatermark;
+            sm.open = sys.open;
+            sm.report_name = sys.report_name;
+
+            // Blocks
+            for (const auto& blk : sys.blocks) {
+                metadata::block_meta bm;
+                bm.sid = blk.sid;
+                bm.type = blk.type;
+                bm.name = blk.name;
+                bm.position = blk.position;
+                bm.zorder = blk.zorder;
+                bm.subsystem_ref = blk.subsystem_ref;
+                bm.port_in = blk.port_in;
+                bm.port_out = blk.port_out;
+
+                // Capture all parameters
+                for (const auto& [k, v] : blk.parameters) {
+                    // Skip position and zorder (already captured separately)
+                    if (k == "Position" || k == "ZOrder") continue;
+                    bm.parameters[k] = v;
+                }
+
+                // Background color is in parameters
+                if (auto it = blk.parameters.find("BackgroundColor"); it != blk.parameters.end()) {
+                    bm.background_color = it->second;
+                }
+
+                // Mask parameters
+                for (const auto& mp : blk.mask_parameters) {
+                    metadata::mask_param mm;
+                    mm.name = mp.name;
+                    mm.type = mp.type;
+                    mm.prompt = mp.prompt;
+                    mm.value = mp.value;
+                    bm.mask_parameters.push_back(std::move(mm));
+                }
+
+                // Port properties
+                for (const auto& pi : blk.input_ports) {
+                    metadata::port_property pp;
+                    pp.port_type = "in";
+                    pp.index = pi.index;
+                    if (!pi.name.empty()) pp.properties["Name"] = pi.name;
+                    if (!pi.propagated_signals.empty()) pp.properties["PropagatedSignals"] = pi.propagated_signals;
+                    bm.port_properties.push_back(std::move(pp));
+                }
+                for (const auto& pi : blk.output_ports) {
+                    metadata::port_property pp;
+                    pp.port_type = "out";
+                    pp.index = pi.index;
+                    if (!pi.name.empty()) pp.properties["Name"] = pi.name;
+                    if (!pi.propagated_signals.empty()) pp.properties["PropagatedSignals"] = pi.propagated_signals;
+                    bm.port_properties.push_back(std::move(pp));
+                }
+
+                sm.blocks.push_back(std::move(bm));
+            }
+
+            // Connections
+            for (const auto& conn : sys.connections) {
+                metadata::connection_meta cm;
+                cm.name = conn.name;
+                cm.zorder = conn.zorder;
+                cm.source = conn.source;
+                cm.destination = conn.destination;
+                cm.points = conn.points;
+                cm.labels = conn.labels;
+
+                for (const auto& br : conn.branches) {
+                    metadata::branch_meta bm;
+                    bm.zorder = br.zorder;
+                    bm.destination = br.destination;
+                    bm.points = br.points;
+                    cm.branches.push_back(std::move(bm));
+                }
+
+                sm.connections.push_back(std::move(cm));
+            }
+
+            return sm;
+        }
+    };
+
+} // namespace oc

--- a/tools/oc_to_mdl/main.cpp
+++ b/tools/oc_to_mdl/main.cpp
@@ -1,0 +1,177 @@
+//
+// Open Controls - OC to MDL Converter
+//
+// Copyright (C) 2026 Daher Alfawares
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+
+#include "../liboc/oc_parser.hpp"
+#include "../liboc/oc_metadata.hpp"
+#include "mdl_writer.hpp"
+#include <iostream>
+#include <fstream>
+#include <filesystem>
+#include <print>
+
+namespace fs = std::filesystem;
+
+namespace {
+
+    void print_usage(std::string_view program) {
+        std::println("Usage: {} <input-dir> [-o output.mdl]", program);
+        std::println("");
+        std::println("Converts OC files back to Simulink MDL format.");
+        std::println("Reads .oc files and optional .oc.metadata from the input directory.");
+        std::println("");
+        std::println("Options:");
+        std::println("  -o <file>   Output MDL file path (default: <dir-name>.mdl)");
+    }
+
+    [[nodiscard]] auto read_file(const fs::path& path) -> std::string {
+        std::ifstream in(path);
+        if (!in) return {};
+        return {std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>()};
+    }
+
+} // namespace
+
+auto main(int argc, char* argv[]) -> int {
+    if (argc < 2) {
+        print_usage(argv[0]);
+        return 1;
+    }
+
+    std::string input_dir;
+    std::string output_file;
+
+    for (int i = 1; i < argc; ++i) {
+        std::string_view arg = argv[i];
+        if (arg == "-h" || arg == "--help") {
+            print_usage(argv[0]);
+            return 0;
+        } else if (arg == "-o" && i + 1 < argc) {
+            output_file = argv[++i];
+        } else if (!arg.starts_with('-')) {
+            input_dir = std::string(arg);
+        }
+    }
+
+    if (input_dir.empty()) {
+        std::println(stderr, "Error: No input directory specified");
+        print_usage(argv[0]);
+        return 1;
+    }
+
+    fs::path dir_path(input_dir);
+    if (!fs::is_directory(dir_path)) {
+        std::println(stderr, "Error: {} is not a directory", input_dir);
+        return 1;
+    }
+
+    // Derive model name from directory name (remove -oc suffix)
+    // Normalize path to remove trailing slashes
+    auto normalized = fs::canonical(dir_path);
+    auto dir_name = normalized.filename().string();
+    auto model_name = dir_name;
+    if (model_name.ends_with("-oc")) {
+        model_name = model_name.substr(0, model_name.size() - 3);
+    }
+
+    if (output_file.empty()) {
+        output_file = model_name + ".mdl";
+    }
+
+    std::println("Input directory: {}", input_dir);
+    std::println("Model name: {}", model_name);
+
+    // Step 1: Scan for .oc files
+    std::vector<fs::path> oc_paths;
+    for (const auto& entry : fs::directory_iterator(dir_path)) {
+        if (entry.path().extension() == ".oc") {
+            oc_paths.push_back(entry.path());
+        }
+    }
+
+    std::ranges::sort(oc_paths);
+
+    if (oc_paths.empty()) {
+        std::println(stderr, "Error: No .oc files found in {}", input_dir);
+        return 1;
+    }
+
+    std::println("Found {} .oc file(s)", oc_paths.size());
+
+    // Step 2: Parse each .oc file
+    std::vector<oc::parser::oc_file> oc_files;
+    bool parse_ok = true;
+
+    for (const auto& path : oc_paths) {
+        std::println("  Parsing: {}", path.filename().string());
+        auto source = read_file(path);
+        if (source.empty()) {
+            std::println(stderr, "  Error: Could not read {}", path.string());
+            parse_ok = false;
+            continue;
+        }
+
+        auto result = oc::parser::parse_string(source);
+        if (!result.success) {
+            std::println(stderr, "  Syntax errors in {}:", path.filename().string());
+            for (const auto& err : result.errors) {
+                std::println(stderr, "    {}", err.to_string());
+            }
+            parse_ok = false;
+            continue;
+        }
+
+        oc_files.push_back(std::move(result.file));
+    }
+
+    if (!parse_ok) {
+        std::println(stderr, "Error: Aborting due to parse errors");
+        return 1;
+    }
+
+    // Step 3: Look for matching .oc.metadata file
+    std::optional<oc::metadata::metadata> meta;
+
+    // Search for metadata file: could be <model_name>.oc.metadata in the input dir
+    for (const auto& entry : fs::directory_iterator(dir_path)) {
+        if (entry.path().extension() == ".metadata" &&
+            entry.path().stem().extension() == ".oc") {
+            std::println("Found metadata: {}", entry.path().filename().string());
+            meta = oc::metadata::read_file(entry.path().string());
+            if (!meta) {
+                std::println(stderr, "Warning: Could not parse metadata file, using defaults");
+            }
+            break;
+        }
+    }
+
+    // Step 4: Generate MDL
+    oc::mdl_writer writer;
+    std::string mdl_content;
+
+    if (meta) {
+        std::println("Reconstructing MDL from metadata (verbatim mode)...");
+        mdl_content = writer.write_with_metadata(*meta);
+    } else {
+        std::println("No metadata found, generating MDL with best-guess defaults...");
+        mdl_content = writer.write_with_defaults(oc_files, model_name);
+    }
+
+    // Step 5: Write output
+    if (std::ofstream out(output_file); out) {
+        out << mdl_content;
+        std::println("Written: {} ({} bytes)", output_file, mdl_content.size());
+    } else {
+        std::println(stderr, "Error: Could not write {}", output_file);
+        return 1;
+    }
+
+    return 0;
+}

--- a/tools/oc_to_mdl/mdl_writer.hpp
+++ b/tools/oc_to_mdl/mdl_writer.hpp
@@ -1,0 +1,574 @@
+//
+// Open Controls - MDL Writer (OC + metadata → MDL)
+//
+// Copyright (C) 2026 Daher Alfawares
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+
+#pragma once
+
+#include "../liboc/oc_metadata.hpp"
+#include "../liboc/oc_parser.hpp"
+#include <string>
+#include <sstream>
+#include <vector>
+#include <map>
+#include <random>
+#include <iomanip>
+#include <algorithm>
+#include <set>
+
+namespace oc {
+
+    class mdl_writer {
+    public:
+        // Write MDL file using metadata (verbatim round-trip)
+        [[nodiscard]] auto write_with_metadata(const metadata::metadata& meta) -> std::string {
+            std::ostringstream out;
+
+            // Header
+            out << "# MathWorks OPC Text Package\n";
+            out << "Model {\n";
+            out << "  Version  24.2\n";
+            out << "  Description \"Simulink model saved in R2024b\"\n";
+            out << "}\n";
+            out << "__MWOPC_PACKAGE_BEGIN__ R2024b\n";
+
+            // Write parts in original order if available, using raw content verbatim
+            if (!meta.part_order.empty()) {
+                for (const auto& path : meta.part_order) {
+                    if (auto it = meta.raw_parts.find(path); it != meta.raw_parts.end()) {
+                        write_part(out, path, it->second);
+                    }
+                }
+            } else {
+                // Fallback: write raw parts in sorted order
+                for (const auto& [path, content] : meta.raw_parts) {
+                    write_part(out, path, content);
+                }
+            }
+
+            return out.str();
+        }
+
+        // Write MDL file with best-guess defaults (no metadata)
+        [[nodiscard]] auto write_with_defaults(
+            const std::vector<parser::oc_file>& oc_files,
+            const std::string& model_name) -> std::string
+        {
+            std::ostringstream out;
+
+            auto uuid = generate_uuid();
+            auto library_name = model_name;
+            // Remove _lib suffix if present
+            if (library_name.size() > 4 && library_name.ends_with("_lib")) {
+                library_name = library_name.substr(0, library_name.size() - 4);
+            }
+
+            // Header
+            out << "# MathWorks OPC Text Package\n";
+            out << "Model {\n";
+            out << "  Version  24.2\n";
+            out << "  Description \"Simulink model saved in R2024b\"\n";
+            out << "}\n";
+            out << "__MWOPC_PACKAGE_BEGIN__ R2024b\n";
+
+            // Generate default parts
+            write_part(out, "/[Content_Types].xml", generate_default_content_types());
+            write_part(out, "/_rels/.rels", generate_default_rels());
+            write_part(out, "/metadata/coreProperties.xml", generate_default_core_properties());
+            write_part(out, "/metadata/mwcoreProperties.xml", generate_default_mw_core_properties());
+            write_part(out, "/metadata/mwcorePropertiesExtension.xml",
+                       generate_default_mw_core_extension(uuid));
+            write_part(out, "/metadata/mwcorePropertiesReleaseInfo.xml",
+                       generate_default_release_info());
+            write_part(out, "/simulink/_rels/blockdiagram.xml.rels",
+                       generate_default_blockdiagram_rels());
+            write_part(out, "/simulink/_rels/configSetInfo.xml.rels",
+                       generate_default_config_set_info_rels());
+            write_part(out, "/simulink/bddefaults.xml", generate_default_bd_defaults());
+            write_part(out, "/simulink/blockdiagram.xml",
+                       generate_default_blockdiagram(uuid, model_name));
+            write_part(out, "/simulink/configSet0.xml", generate_default_config_set());
+            write_part(out, "/simulink/configSetInfo.xml", generate_default_config_set_info());
+            write_part(out, "/simulink/modelDictionary.xml", generate_default_model_dictionary());
+
+            // Generate system_root with subsystem blocks for each element
+            auto root_xml = generate_default_root_system(oc_files);
+            write_part(out, "/simulink/systems/system_root.xml", root_xml);
+
+            // Generate subsystem XMLs for each element
+            int sys_counter = 1;
+            for (const auto& file : oc_files) {
+                for (const auto& ns : file.namespaces) {
+                    for (const auto& elem : ns.elements) {
+                        auto sys_xml = generate_default_element_system(elem, sys_counter);
+                        write_part(out, "/simulink/systems/system_" + std::to_string(sys_counter) + ".xml", sys_xml);
+                        ++sys_counter;
+                    }
+                }
+            }
+
+            write_part(out, "/simulink/windowsInfo.xml", generate_default_windows_info());
+
+            return out.str();
+        }
+
+    private:
+        void write_part(std::ostringstream& out, const std::string& path, const std::string& content) {
+            // Check if content looks like BASE64 (binary) data
+            bool is_base64 = path.ends_with(".mxarray");
+            out << "__MWOPC_PART_BEGIN__ " << path;
+            if (is_base64) out << " BASE64";
+            out << "\n" << content << "\n";
+            // XML parts have a blank line separator; BASE64 parts don't
+            if (!is_base64) out << "\n";
+        }
+
+        // ─── System XML Generation from metadata ────────────────────────────
+        [[nodiscard]] auto generate_system_xml(const metadata::system_meta& sys) -> std::string {
+            std::ostringstream out;
+            out << "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n";
+            out << "<System>\n";
+
+            // System properties
+            if (!sys.location.empty()) {
+                out << "  <P Name=\"Location\">[";
+                for (std::size_t i = 0; i < sys.location.size(); ++i) {
+                    if (i > 0) out << ", ";
+                    out << sys.location[i];
+                }
+                out << "]</P>\n";
+            }
+            if (!sys.open.empty()) {
+                out << "  <P Name=\"Open\">" << sys.open << "</P>\n";
+            }
+            out << "  <P Name=\"ZoomFactor\">" << sys.zoom_factor << "</P>\n";
+            if (!sys.report_name.empty()) {
+                out << "  <P Name=\"ReportName\">" << sys.report_name << "</P>\n";
+            }
+            if (sys.sid_highwatermark > 0) {
+                out << "  <P Name=\"SIDHighWatermark\">" << sys.sid_highwatermark << "</P>\n";
+            }
+
+            // Blocks
+            for (const auto& blk : sys.blocks) {
+                out << "  <Block BlockType=\"" << blk.type << "\" Name=\"" << xml_escape(blk.name) << "\" SID=\"" << blk.sid << "\">\n";
+
+                // Port counts
+                if (blk.port_in > 0 || blk.port_out > 0) {
+                    out << "    <PortCounts";
+                    if (blk.port_in > 0) out << " in=\"" << blk.port_in << "\"";
+                    if (blk.port_out > 0) out << " out=\"" << blk.port_out << "\"";
+                    out << "/>\n";
+                }
+
+                // Position
+                if (!blk.position.empty()) {
+                    out << "    <P Name=\"Position\">[";
+                    for (std::size_t i = 0; i < blk.position.size(); ++i) {
+                        if (i > 0) out << ", ";
+                        out << blk.position[i];
+                    }
+                    out << "]</P>\n";
+                }
+
+                // ZOrder
+                out << "    <P Name=\"ZOrder\">" << blk.zorder << "</P>\n";
+
+                // Other parameters
+                for (const auto& [k, v] : blk.parameters) {
+                    if (k == "Position" || k == "ZOrder") continue;
+                    out << "    <P Name=\"" << k << "\">" << xml_escape(v) << "</P>\n";
+                }
+
+                // Mask
+                if (!blk.mask_parameters.empty()) {
+                    out << "    <Mask>\n";
+                    if (!blk.mask_display_xml.empty()) {
+                        out << "      " << blk.mask_display_xml << "\n";
+                    } else {
+                        out << "      <Display RunInitForIconRedraw=\"off\"/>\n";
+                    }
+                    for (const auto& mp : blk.mask_parameters) {
+                        out << "      <MaskParameter Name=\"" << mp.name << "\" Type=\"" << mp.type << "\"";
+                        if (!mp.show_tooltip.empty()) out << " ShowTooltip=\"" << mp.show_tooltip << "\"";
+                        out << ">\n";
+                        out << "        <Prompt>" << xml_escape(mp.prompt) << "</Prompt>\n";
+                        out << "        <Value>" << xml_escape(mp.value) << "</Value>\n";
+                        out << "      </MaskParameter>\n";
+                    }
+                    out << "    </Mask>\n";
+                }
+
+                // Port properties
+                if (!blk.port_properties.empty()) {
+                    out << "    <PortProperties>\n";
+                    for (const auto& pp : blk.port_properties) {
+                        out << "      <Port Type=\"" << pp.port_type << "\" Index=\"" << pp.index << "\">\n";
+                        for (const auto& [k, v] : pp.properties) {
+                            out << "        <P Name=\"" << k << "\">" << xml_escape(v) << "</P>\n";
+                        }
+                        out << "      </Port>\n";
+                    }
+                    out << "    </PortProperties>\n";
+                }
+
+                // Subsystem reference
+                if (!blk.subsystem_ref.empty()) {
+                    out << "    <System Ref=\"" << blk.subsystem_ref << "\"/>\n";
+                }
+
+                out << "  </Block>\n";
+            }
+
+            // Connections
+            for (const auto& conn : sys.connections) {
+                out << "  <Line>\n";
+                if (!conn.name.empty()) {
+                    out << "    <P Name=\"Name\">" << xml_escape(conn.name) << "</P>\n";
+                }
+                out << "    <P Name=\"ZOrder\">" << conn.zorder << "</P>\n";
+                if (!conn.labels.empty()) {
+                    out << "    <P Name=\"Labels\">" << conn.labels << "</P>\n";
+                }
+                out << "    <P Name=\"Src\">" << conn.source << "</P>\n";
+
+                if (!conn.points.empty()) {
+                    out << "    <P Name=\"Points\">[";
+                    for (std::size_t i = 0; i < conn.points.size(); ++i) {
+                        if (i > 0) out << ", ";
+                        out << conn.points[i];
+                    }
+                    out << "]</P>\n";
+                }
+
+                if (!conn.destination.empty() && conn.branches.empty()) {
+                    out << "    <P Name=\"Dst\">" << conn.destination << "</P>\n";
+                }
+
+                for (const auto& br : conn.branches) {
+                    out << "    <Branch>\n";
+                    out << "      <P Name=\"ZOrder\">" << br.zorder << "</P>\n";
+                    if (!br.points.empty()) {
+                        out << "      <P Name=\"Points\">[";
+                        for (std::size_t i = 0; i < br.points.size(); ++i) {
+                            if (i > 0) out << ", ";
+                            out << br.points[i];
+                        }
+                        out << "]</P>\n";
+                    }
+                    out << "      <P Name=\"Dst\">" << br.destination << "</P>\n";
+                    out << "    </Branch>\n";
+                }
+
+                out << "  </Line>\n";
+            }
+
+            out << "</System>";
+            return out.str();
+        }
+
+        // ─── Default generators (for when metadata is missing) ──────────────
+
+        [[nodiscard]] auto generate_default_content_types() -> std::string {
+            return R"(<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default ContentType="application/vnd.mathworks.matlab.mxarray+binary" Extension="mxarray"/>
+  <Default ContentType="application/vnd.openxmlformats-package.relationships+xml" Extension="rels"/>
+  <Default ContentType="application/vnd.mathworks.simulink.mdl+xml" Extension="xml"/>
+  <Override ContentType="application/vnd.openxmlformats-package.core-properties+xml" PartName="/metadata/coreProperties.xml"/>
+  <Override ContentType="application/vnd.mathworks.package.coreProperties+xml" PartName="/metadata/mwcoreProperties.xml"/>
+  <Override ContentType="application/vnd.mathworks.package.corePropertiesExtension+xml" PartName="/metadata/mwcorePropertiesExtension.xml"/>
+  <Override ContentType="application/vnd.mathworks.package.corePropertiesReleaseInfo+xml" PartName="/metadata/mwcorePropertiesReleaseInfo.xml"/>
+  <Override ContentType="application/vnd.mathworks.simulink.configSet+xml" PartName="/simulink/configSet0.xml"/>
+  <Override ContentType="application/vnd.mathworks.simulink.configSetInfo+xml" PartName="/simulink/configSetInfo.xml"/>
+  <Override ContentType="application/vnd.mathworks.simulink.mf0+xml" PartName="/simulink/modelDictionary.xml"/>
+  <Override ContentType="application/vnd.mathworks.simulink.blockDiagram+xml" PartName="/simulink/windowsInfo.xml"/>
+</Types>)";
+        }
+
+        [[nodiscard]] auto generate_default_rels() -> std::string {
+            return R"(<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="blockDiagram" Target="simulink/blockdiagram.xml" Type="http://schemas.mathworks.com/simulink/2010/relationships/blockDiagram"/>
+  <Relationship Id="blockDiagramDefaults" Target="simulink/bddefaults.xml" Type="http://schemas.mathworks.com/simulink/2017/relationships/blockDiagramDefaults"/>
+  <Relationship Id="configSetInfo" Target="simulink/configSetInfo.xml" Type="http://schemas.mathworks.com/simulink/2014/relationships/configSetInfo"/>
+  <Relationship Id="modelDictionary" Target="simulink/modelDictionary.xml" Type="http://schemas.mathworks.com/simulinkModel/2016/relationships/modelDictionary"/>
+  <Relationship Id="rId1" Target="metadata/mwcoreProperties.xml" Type="http://schemas.mathworks.com/package/2012/relationships/coreProperties"/>
+  <Relationship Id="rId2" Target="metadata/mwcorePropertiesExtension.xml" Type="http://schemas.mathworks.com/package/2014/relationships/corePropertiesExtension"/>
+  <Relationship Id="rId3" Target="metadata/mwcorePropertiesReleaseInfo.xml" Type="http://schemas.mathworks.com/package/2019/relationships/corePropertiesReleaseInfo"/>
+  <Relationship Id="rId4" Target="metadata/coreProperties.xml" Type="http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties"/>
+</Relationships>)";
+        }
+
+        [[nodiscard]] auto generate_default_core_properties() -> std::string {
+            return R"(<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<cp:coreProperties xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/core-properties" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcmitype="http://purl.org/dc/dcmitype/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <cp:category>library</cp:category>
+  <dcterms:created xsi:type="dcterms:W3CDTF">2026-01-01T00:00:00Z</dcterms:created>
+  <dc:creator>oc_to_mdl</dc:creator>
+  <cp:lastModifiedBy>oc_to_mdl</cp:lastModifiedBy>
+  <dcterms:modified xsi:type="dcterms:W3CDTF">2026-01-01T00:00:00Z</dcterms:modified>
+  <cp:revision>1.0</cp:revision>
+  <cp:version>R2024b</cp:version>
+</cp:coreProperties>)";
+        }
+
+        [[nodiscard]] auto generate_default_mw_core_properties() -> std::string {
+            return R"(<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<mwcoreProperties xmlns="http://schemas.mathworks.com/package/2012/coreProperties">
+  <contentType>application/vnd.mathworks.simulink.model</contentType>
+  <contentTypeFriendlyName>Simulink Model</contentTypeFriendlyName>
+  <matlabRelease>R2024b</matlabRelease>
+</mwcoreProperties>)";
+        }
+
+        [[nodiscard]] auto generate_default_mw_core_extension(const std::string& uuid) -> std::string {
+            return "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\" ?>\n"
+                   "<mwcoreProperties xmlns=\"http://schemas.mathworks.com/package/2014/corePropertiesExtension\">\n"
+                   "  <uuid>" + uuid + "</uuid>\n"
+                   "</mwcoreProperties>";
+        }
+
+        [[nodiscard]] auto generate_default_release_info() -> std::string {
+            return R"(<?xml version="1.0" encoding="UTF-8"?>
+<MathWorks_version_info>
+  <version>24.2.0.2863752</version>
+  <release>R2024b</release>
+  <description>Update 5</description>
+  <date>Jan 31 2025</date>
+  <checksum>2052451712</checksum>
+</MathWorks_version_info>)";
+        }
+
+        [[nodiscard]] auto generate_default_blockdiagram_rels() -> std::string {
+            return R"(<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="system_root" Target="systems/system_root.xml" Type="http://schemas.mathworks.com/simulink/2010/relationships/system"/>
+  <Relationship Id="windowsInfo" Target="windowsInfo.xml" Type="http://schemas.mathworks.com/simulinkModel/2019/relationships/windowsInfo"/>
+</Relationships>)";
+        }
+
+        [[nodiscard]] auto generate_default_config_set_info_rels() -> std::string {
+            return R"(<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="configSet0" Target="configSet0.xml" Type="http://schemas.mathworks.com/simulink/2014/relationships/configSet"/>
+</Relationships>)";
+        }
+
+        [[nodiscard]] auto generate_default_bd_defaults() -> std::string {
+            return R"(<?xml version="1.0" encoding="utf-8"?>
+<BlockDiagramDefaults>
+  <MaskDefaults SelfModifiable="off">
+    <Display IconFrame="on" IconOpaque="opaque" RunInitForIconRedraw="analyze" IconRotate="none" PortRotate="default" IconUnits="autoscale"/>
+    <MaskParameter Evaluate="on" Tunable="on" NeverSave="off" Internal="off" ReadOnly="off" Enabled="on" Visible="on" ToolTip="on"/>
+    <DialogControl>
+      <ControlOptions Visible="on" Enabled="on" Row="new" HorizontalStretch="on" PromptLocation="top" Orientation="horizontal" Scale="linear" TextType="Plain Text" Expand="off" ShowFilter="on" ShowParameterName="on" WordWrap="on" AlignPrompts="off"/>
+    </DialogControl>
+  </MaskDefaults>
+</BlockDiagramDefaults>)";
+        }
+
+        [[nodiscard]] auto generate_default_blockdiagram(const std::string& uuid, [[maybe_unused]] const std::string& model_name) -> std::string {
+            std::ostringstream out;
+            out << "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n";
+            out << "<ModelInformation Version=\"1.0\">\n";
+            out << "  <Library>\n";
+            out << "    <P Name=\"ModelUUID\">" << uuid << "</P>\n";
+            out << "    <P Name=\"LibraryType\">BlockLibrary</P>\n";
+            out << "    <System Ref=\"system_root\"/>\n";
+            out << "  </Library>\n";
+            out << "</ModelInformation>";
+            return out.str();
+        }
+
+        [[nodiscard]] auto generate_default_config_set() -> std::string {
+            return R"(<?xml version="1.0" encoding="utf-8"?>
+<ConfigSet>
+  <Object Version="24.1.0" ClassName="Simulink.ConfigSet">
+    <P Name="DisabledProps" Class="double">[]</P>
+    <P Name="Description"/>
+    <Array PropName="Components" Type="Handle" Dimension="1*1">
+      <Object ObjectID="2" Version="24.1.0" ClassName="Simulink.SolverCC">
+        <P Name="DisabledProps" Class="double">[]</P>
+        <P Name="Description"/>
+        <P Name="Components" Class="double">[]</P>
+        <P Name="SolverName">VariableStepAuto</P>
+      </Object>
+    </Array>
+  </Object>
+</ConfigSet>)";
+        }
+
+        [[nodiscard]] auto generate_default_config_set_info() -> std::string {
+            return R"(<?xml version="1.0" encoding="utf-8"?>
+<ConfigSetInfo>
+  <ConfigSet Ref="configSet0" Active="true"/>
+</ConfigSetInfo>)";
+        }
+
+        [[nodiscard]] auto generate_default_model_dictionary() -> std::string {
+            return R"(<?xml version="1.0" encoding="utf-8"?>
+<ModelDictionary/>)";
+        }
+
+        [[nodiscard]] auto generate_default_windows_info() -> std::string {
+            return R"(<?xml version="1.0" encoding="utf-8"?>
+<WindowsInfo>
+  <Object PropName="BdWindowsInfo" ObjectID="1" ClassName="Simulink.BDWindowsInfo">
+    <Object PropName="WindowsInfo" ObjectID="2" ClassName="Simulink.WindowInfo">
+      <P Name="IsActive" Class="logical">1</P>
+      <P Name="Location" Class="double">[0.0, 0.0, 1920.0, 1080.0]</P>
+    </Object>
+  </Object>
+</WindowsInfo>)";
+        }
+
+        // ─── Default system generators ──────────────────────────────────────
+
+        [[nodiscard]] auto generate_default_root_system(
+            const std::vector<parser::oc_file>& oc_files) -> std::string
+        {
+            std::ostringstream out;
+            out << "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n";
+            out << "<System>\n";
+            out << "  <P Name=\"Location\">[-1, -8, 1921, 1153]</P>\n";
+            out << "  <P Name=\"ZoomFactor\">100</P>\n";
+
+            int sid = 1;
+            int x = 100;
+            int y = 100;
+
+            for (const auto& file : oc_files) {
+                for (const auto& ns : file.namespaces) {
+                    for (const auto& elem : ns.elements) {
+                        // Count inports/outports from element sections
+                        int in_count = 0;
+                        int out_count = 0;
+                        for (const auto& sec : elem.sections) {
+                            if (sec.kind == "input") in_count = static_cast<int>(sec.variables.size());
+                            if (sec.kind == "output") out_count = static_cast<int>(sec.variables.size());
+                        }
+
+                        out << "  <Block BlockType=\"SubSystem\" Name=\"" << xml_escape(elem.name) << "\" SID=\"" << sid << "\">\n";
+                        if (in_count > 0 || out_count > 0) {
+                            out << "    <PortCounts";
+                            if (in_count > 0) out << " in=\"" << in_count << "\"";
+                            if (out_count > 0) out << " out=\"" << out_count << "\"";
+                            out << "/>\n";
+                        }
+                        out << "    <P Name=\"Position\">[" << x << ", " << y << ", " << (x + 120) << ", " << (y + 80) << "]</P>\n";
+                        out << "    <P Name=\"ZOrder\">" << sid << "</P>\n";
+                        out << "    <System Ref=\"system_" << sid << "\"/>\n";
+                        out << "  </Block>\n";
+
+                        y += 120;
+                        if (y > 800) { y = 100; x += 200; }
+                        ++sid;
+                    }
+                }
+            }
+
+            out << "</System>";
+            return out.str();
+        }
+
+        [[nodiscard]] auto generate_default_element_system(
+            const parser::oc_element& elem,
+            [[maybe_unused]] int sys_id) -> std::string
+        {
+            std::ostringstream out;
+            out << "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n";
+            out << "<System>\n";
+            out << "  <P Name=\"Location\">[-1, -8, 1921, 1033]</P>\n";
+            out << "  <P Name=\"ZoomFactor\">100</P>\n";
+
+            int sid = 1;
+            int x = 100;
+            int y = 50;
+
+            // Generate Inport blocks
+            for (const auto& sec : elem.sections) {
+                if (sec.kind != "input") continue;
+                int port_num = 1;
+                for (const auto& var : sec.variables) {
+                    out << "  <Block BlockType=\"Inport\" Name=\"" << xml_escape(var.name) << "\" SID=\"" << sid << "\">\n";
+                    out << "    <P Name=\"Position\">[" << x << ", " << y << ", " << (x + 30) << ", " << (y + 14) << "]</P>\n";
+                    out << "    <P Name=\"ZOrder\">" << sid << "</P>\n";
+                    if (port_num > 1) {
+                        out << "    <P Name=\"Port\">" << port_num << "</P>\n";
+                    }
+                    out << "  </Block>\n";
+                    y += 50;
+                    ++sid;
+                    ++port_num;
+                }
+            }
+
+            // Generate Outport blocks
+            x = 600;
+            y = 50;
+            for (const auto& sec : elem.sections) {
+                if (sec.kind != "output") continue;
+                int port_num = 1;
+                for (const auto& var : sec.variables) {
+                    out << "  <Block BlockType=\"Outport\" Name=\"" << xml_escape(var.name) << "\" SID=\"" << sid << "\">\n";
+                    out << "    <P Name=\"Position\">[" << x << ", " << y << ", " << (x + 30) << ", " << (y + 14) << "]</P>\n";
+                    out << "    <P Name=\"ZOrder\">" << sid << "</P>\n";
+                    if (port_num > 1) {
+                        out << "    <P Name=\"Port\">" << port_num << "</P>\n";
+                    }
+                    out << "  </Block>\n";
+                    y += 50;
+                    ++sid;
+                    ++port_num;
+                }
+            }
+
+            out << "</System>";
+            return out.str();
+        }
+
+        // ─── Utility ────────────────────────────────────────────────────────
+
+        [[nodiscard]] static auto xml_escape(const std::string& s) -> std::string {
+            std::string result;
+            result.reserve(s.size());
+            for (char c : s) {
+                switch (c) {
+                    case '&': result += "&amp;"; break;
+                    case '<': result += "&lt;"; break;
+                    case '>': result += "&gt;"; break;
+                    case '"': result += "&quot;"; break;
+                    case '\'': result += "&apos;"; break;
+                    default: result += c;
+                }
+            }
+            return result;
+        }
+
+        [[nodiscard]] static auto generate_uuid() -> std::string {
+            std::random_device rd;
+            std::mt19937 gen(rd());
+            std::uniform_int_distribution<int> dist(0, 15);
+
+            auto hex_char = [&]() -> char {
+                int v = dist(gen);
+                return v < 10 ? static_cast<char>('0' + v) : static_cast<char>('a' + v - 10);
+            };
+
+            std::string uuid;
+            for (int i = 0; i < 32; ++i) {
+                if (i == 8 || i == 12 || i == 16 || i == 20) uuid += '-';
+                uuid += hex_char();
+            }
+            return uuid;
+        }
+    };
+
+} // namespace oc


### PR DESCRIPTION
Enable lossless round-tripping: mdl_to_oc now emits a .oc.metadata JSON file alongside .oc files, capturing all UI/presentation data (block positions, connection routing, solver config, raw OPC parts). The new oc_to_mdl tool reconstructs MDL files from .oc + metadata (near-identical output), or generates best-guess defaults when metadata is missing.

New shared libraries in tools/liboc/:
- oc_parser.hpp: OC format lexer/parser producing an AST
- oc_json.hpp: minimal self-contained JSON parser/emitter
- oc_metadata.hpp: .oc.metadata format reader/writer